### PR TITLE
Remove duplicate intersections and Add option for only first hit

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -115,7 +115,7 @@ const addRaycaster = () => {
             dirvec.copy(origvec).multiplyScalar(-1).normalize();
 
             raycaster.set(origvec, dirvec);
-            const res = raycaster.intersectObject(containerObj, true);
+            const res = raycaster.intersectObject(containerObj, true, null, true);
             const length = res.length ? res[0].distance : pointDist;
             
             hitMesh.position.set(pointDist - length, 0, 0);

--- a/index.js
+++ b/index.js
@@ -12,8 +12,10 @@ THREE.Mesh.prototype.raycast = function(raycaster, intersects) {
         inverseMatrix.getInverse(this.matrixWorld);
         ray.copy(raycaster.ray).applyMatrix4(inverseMatrix);
 
-        const res = this.geometry.boundsTree.raycastFirst(this, raycaster, ray);
-        if (res) intersects.push(res);
+        let seenFaces = {};
+        this.geometry.boundsTree.raycast(this, raycaster, ray, intersects, seenFaces);
+        //const res = this.geometry.boundsTree.raycastFirst(this, raycaster, ray);
+        //if (res) intersects.push(res);
     } else {
         origRaycast.call(this, raycaster, intersects);
     }

--- a/index.js
+++ b/index.js
@@ -4,6 +4,8 @@ import MeshBVH from './lib/MeshBVH.js'
 const ray = new THREE.Ray();
 const inverseMatrix = new THREE.Matrix4();
 const origRaycast = THREE.Mesh.prototype.raycast;
+const origIntersectObject = THREE.Raycaster.prototype.intersectObject;
+const origIntersectObjects = THREE.Raycaster.prototype.intersectObjects;
 
 THREE.Mesh.prototype.raycast = function(raycaster, intersects) {
     if (this.geometry.boundsTree) {
@@ -12,13 +14,26 @@ THREE.Mesh.prototype.raycast = function(raycaster, intersects) {
         inverseMatrix.getInverse(this.matrixWorld);
         ray.copy(raycaster.ray).applyMatrix4(inverseMatrix);
 
-        let seenFaces = {};
-        this.geometry.boundsTree.raycast(this, raycaster, ray, intersects, seenFaces);
-        //const res = this.geometry.boundsTree.raycastFirst(this, raycaster, ray);
-        //if (res) intersects.push(res);
+        if (raycaster.firstHitOnly === true) {
+            const res = this.geometry.boundsTree.raycastFirst(this, raycaster, ray);
+            if (res) intersects.push(res);
+        } else {
+            let seenFaces = {};
+            this.geometry.boundsTree.raycast(this, raycaster, ray, intersects, seenFaces);
+        }
     } else {
         origRaycast.call(this, raycaster, intersects);
     }
+}
+
+THREE.Raycaster.prototype.intersectObject = function ( object, recursive, optionalTarget, firstHitOnly = false) {
+  this.firstHitOnly = firstHitOnly;
+  return origIntersectObject.call(this, object, recursive, optionalTarget);
+}
+
+THREE.Raycaster.prototype.intersectObjects = function ( objects, recursive, optionalTarget, firstHitOnly = false) {
+  this.firstHitOnly = firstHitOnly;
+  return origIntersectObjects.call(this, objects, recursive, optionalTarget);
 }
 
 THREE.Geometry.prototype.computeBoundsTree = function(strat) {

--- a/lib/GeometryUtilities.js
+++ b/lib/GeometryUtilities.js
@@ -116,11 +116,11 @@ const shrinkSphereTo = (tris, sphere, geo, getValFunc) => {
 // Copied from mesh raycasting
 const intersectionPoint = new THREE.Vector3();
 const intersectTri = (mesh, geo, raycaster, ray, tri, intersections, seenFaces) => {
+    const faceIndex = tri;
+    if (seenFaces != null && seenFaces[faceIndex]) {
+        return null;
+    }
     if (geo.isBufferGeometry) {
-        const faceIndex = tri;
-        if (seenFaces != null && seenFaces[faceIndex]) {
-            return null;
-        }
         tri = tri * 3;
         const a = geo.index ? geo.index.getX(tri) : tri;
         const b = geo.index ? geo.index.getX(tri + 1) : tri + 1;
@@ -129,10 +129,10 @@ const intersectTri = (mesh, geo, raycaster, ray, tri, intersections, seenFaces) 
         const intersection = checkBufferGeometryIntersection(mesh, raycaster, ray, geo.attributes.position, geo.attributes.uv, a, b, c);
 
         if (intersection) {
-            seenFaces[faceIndex] = true;
-            if (geo.index) {
-              intersection.faceIndex = faceIndex; // triangle number in indices buffer semantics
+            if (seenFaces != null) {
+                seenFaces[faceIndex] = true;
             }
+            intersection.faceIndex = faceIndex; // triangle number
             if (intersections) intersections.push(intersection);
             return intersection;
         }
@@ -154,6 +154,10 @@ const intersectTri = (mesh, geo, raycaster, ray, tri, intersections, seenFaces) 
             const intersection = checkIntersection(mesh, faceMaterial, raycaster, ray, fvA, fvB, fvC, intersectionPoint);
 
             if (intersection) {
+
+                if (seenFaces != null) {
+                    seenFaces[faceIndex] = true;
+                }
 
                 if (uvs && uvs[ f ]) {
 

--- a/lib/GeometryUtilities.js
+++ b/lib/GeometryUtilities.js
@@ -115,8 +115,12 @@ const shrinkSphereTo = (tris, sphere, geo, getValFunc) => {
 // For BVH code specifically. Does not check morph targets
 // Copied from mesh raycasting
 const intersectionPoint = new THREE.Vector3();
-const intersectTri = (mesh, geo, raycaster, ray, tri, intersections) => {
+const intersectTri = (mesh, geo, raycaster, ray, tri, intersections, seenFaces) => {
     if (geo.isBufferGeometry) {
+        const faceIndex = tri;
+        if (seenFaces != null && seenFaces[faceIndex]) {
+            return null;
+        }
         tri = tri * 3;
         const a = geo.index ? geo.index.getX(tri) : tri;
         const b = geo.index ? geo.index.getX(tri + 1) : tri + 1;
@@ -125,7 +129,10 @@ const intersectTri = (mesh, geo, raycaster, ray, tri, intersections) => {
         const intersection = checkBufferGeometryIntersection(mesh, raycaster, ray, geo.attributes.position, geo.attributes.uv, a, b, c);
 
         if (intersection) {
-            intersection.index = a; // triangle number in positions buffer semantics
+            seenFaces[faceIndex] = true;
+            if (geo.index) {
+              intersection.faceIndex = faceIndex; // triangle number in indices buffer semantics
+            }
             if (intersections) intersections.push(intersection);
             return intersection;
         }
@@ -168,9 +175,9 @@ const intersectTri = (mesh, geo, raycaster, ray, tri, intersections) => {
     return null;    
 }
 
-const intersectTris = (mesh, geo, raycaster, ray, tris, intersections) => {
+const intersectTris = (mesh, geo, raycaster, ray, tris, intersections, seenFaces) => {
     for (let i = 0, l = tris.length; i < l; i ++) {
-        intersectTri(mesh, geo, raycaster, ray, tris[i], intersections);
+        intersectTri(mesh, geo, raycaster, ray, tris[i], intersections, seenFaces);
     }
 }
 

--- a/lib/IntersectionUtilities.js
+++ b/lib/IntersectionUtilities.js
@@ -1,7 +1,6 @@
 import { Mesh, Matrix4, Ray, Sphere, Vector3, Vector2, Triangle, DoubleSide, BackSide, Face3 } from '../node_modules/three/build/three.module.js'
 
 // From THREE.js Mesh raycast
-var inverseMatrix = new Matrix4();
 var ray = new Ray();
 var sphere = new Sphere();
 

--- a/lib/MeshBVH.js
+++ b/lib/MeshBVH.js
@@ -31,11 +31,11 @@ class MeshBVHNode {
             (ray.intersectsBox(this.boundingBox) || this.boundingBox.containsPoint(ray.origin));
     }
 
-    raycast(mesh, raycaster, ray, intersects) {
+    raycast(mesh, raycaster, ray, intersects, seenFaces) {
         if (!this.intersectsRay(ray)) return;
 
-        if (this.tris) intersectTris(mesh, this.geometry, raycaster, ray, this.tris, intersects);
-        else this.children.forEach(c => c.raycast(mesh, raycaster, ray, intersects));
+        if (this.tris) intersectTris(mesh, this.geometry, raycaster, ray, this.tris, intersects, seenFaces);
+        else this.children.forEach(c => c.raycast(mesh, raycaster, ray, intersects, seenFaces));
     }
 
     raycastFirst(mesh, raycaster, ray) {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   
   "scripts": {
     "serve": "static-server",
-    "build": "webpack",
+    "build": "webpack"
   },
   
   "repository": {


### PR DESCRIPTION
- Added option to check only first hit by changing the raycaster intersectObject[s] calls. So 
`const res = raycaster.intersectObject(containerObj, true);`
gets all intersections and
`const res = raycaster.intersectObject(containerObj, true, null, true);`
stops after the first intersection.
- Removes duplicate intersections when getting all intersections so the result matches what you'd get from the default raycaster. Duplicates showed up because the same face can show up in multiple nodes, so I keep track of which faces have been checked already. (While i was at it I changed the faceIndex to match the latest changes in Three since it wasn't unique before)