### PR TITLE
Speed up some triangle math hotspots

### DIFF
--- a/lib/GeometryUtilities.js
+++ b/lib/GeometryUtilities.js
@@ -1,9 +1,6 @@
 import * as THREE from '../node_modules/three/build/three.module.js';
 import { checkIntersection, checkBufferGeometryIntersection, uvIntersection } from './IntersectionUtilities.js';
 
-// reusable vectors
-const vectemp = new THREE.Vector3();
-const bndtemp = new THREE.Box3();
 const abcFields = [ 'a', 'b', 'c' ];
 const xyzFields = [ 'x', 'y', 'z' ];
 
@@ -46,7 +43,9 @@ const getLongestEdgeIndex = bb => {
 // triangles in the geometry
 const getAverage = ( tris, avg, geo, getValFunc ) => {
 
-	avg.set( 0, 0, 0 );
+	let avgx = 0;
+	let avgy = 0;
+	let avgz = 0;
 
 	for ( let i = 0, l = tris.length; i < l; i ++ ) {
 
@@ -54,17 +53,17 @@ const getAverage = ( tris, avg, geo, getValFunc ) => {
 
 		for ( let v = 0; v < 3; v ++ ) {
 
-			avg.x += getValFunc( geo, tri, v, 0 );
-			avg.y += getValFunc( geo, tri, v, 1 );
-			avg.z += getValFunc( geo, tri, v, 2 );
+			avgx += getValFunc( geo, tri, v, 0 );
+			avgy += getValFunc( geo, tri, v, 1 );
+			avgz += getValFunc( geo, tri, v, 2 );
 
 		}
 
 	}
 
-	avg.x /= tris.length * 3;
-	avg.y /= tris.length * 3;
-	avg.z /= tris.length * 3;
+	avg.x = avgx / ( tris.length * 3 );
+	avg.y = avgy / ( tris.length * 3 );
+	avg.z = avgz / ( tris.length * 3 );
 
 };
 
@@ -72,13 +71,15 @@ const getAverage = ( tris, avg, geo, getValFunc ) => {
 // the provided triangles
 const shrinkBoundsTo = ( tris, bounds, geo, getValFunc ) => {
 
-	bndtemp.min.x = Infinity;
-	bndtemp.min.y = Infinity;
-	bndtemp.min.z = Infinity;
+	let minx = Infinity;
+	let miny = Infinity;
+	let minz = Infinity;
 
-	bndtemp.max.x = - Infinity;
-	bndtemp.max.y = - Infinity;
-	bndtemp.max.z = - Infinity;
+	let maxx = - Infinity;
+	let maxy = - Infinity;
+	let maxz = - Infinity;
+
+	let x, y, z;
 
 	for ( let i = 0, l = tris.length; i < l; i ++ ) {
 
@@ -86,26 +87,27 @@ const shrinkBoundsTo = ( tris, bounds, geo, getValFunc ) => {
 
 		for ( let v = 0; v < 3; v ++ ) {
 
-			const x = getValFunc( geo, tri, v, 0 );
-			const y = getValFunc( geo, tri, v, 1 );
-			const z = getValFunc( geo, tri, v, 2 );
-
-			vectemp.x = x;
-			vectemp.y = y;
-			vectemp.z = z;
-			bndtemp.expandByPoint( vectemp );
+			x = getValFunc( geo, tri, v, 0 );
+			minx = Math.min( minx, x );
+			maxx = Math.max( maxx, x );
+			y = getValFunc( geo, tri, v, 1 );
+			miny = Math.min( miny, y );
+			maxy = Math.max( maxy, y );
+			z = getValFunc( geo, tri, v, 2 );
+			minz = Math.min( minz, z );
+			maxz = Math.max( maxz, z );
 
 		}
 
 	}
 
-	bounds.min.x = Math.max( bndtemp.min.x, bounds.min.x );
-	bounds.min.y = Math.max( bndtemp.min.y, bounds.min.y );
-	bounds.min.z = Math.max( bndtemp.min.z, bounds.min.z );
+	bounds.min.x = Math.max( minx, bounds.min.x );
+	bounds.min.y = Math.max( miny, bounds.min.y );
+	bounds.min.z = Math.max( minz, bounds.min.z );
 
-	bounds.max.x = Math.min( bndtemp.max.x, bounds.max.x );
-	bounds.max.y = Math.min( bndtemp.max.y, bounds.max.y );
-	bounds.max.z = Math.min( bndtemp.max.z, bounds.max.z );
+	bounds.max.x = Math.min( maxx, bounds.max.x );
+	bounds.max.y = Math.min( maxy, bounds.max.y );
+	bounds.max.z = Math.min( maxz, bounds.max.z );
 
 };
 
@@ -122,14 +124,13 @@ const shrinkSphereTo = ( tris, sphere, geo, getValFunc ) => {
 		for ( let v = 0; v < 3; v ++ ) {
 
 			const x = getValFunc( geo, tri, v, 0 );
+			const dx = center.x - x;
 			const y = getValFunc( geo, tri, v, 1 );
+			const dy = center.y - y;
 			const z = getValFunc( geo, tri, v, 2 );
+			const dz = center.z - z;
 
-			vectemp.x = x;
-			vectemp.y = y;
-			vectemp.z = z;
-
-			maxRadiusSq = Math.max( maxRadiusSq, center.distanceToSquared( vectemp ) );
+			maxRadiusSq = Math.max( maxRadiusSq, dx * dx + dy * dy + dz * dz );
 
 		}
 


### PR DESCRIPTION
This was the lowest-hanging optimization fruit I found without really sacrificing any readability yet -- reduces tree construction time by roughly 10% on my Firefox.