### PR TITLE
Store bounds info in a Float32Array

### DIFF
--- a/lib/BoundsUtilities.js
+++ b/lib/BoundsUtilities.js
@@ -3,7 +3,7 @@
 // and that the box min and max are equal distance in every dimension
 function boundsToArray( bx, sp ) {
 
-	const arr = new Float64Array( 4 );
+	const arr = new Float32Array( 7 );
 	arr[ 0 ] = sp.radius;
 
 	arr[ 1 ] = sp.center.x;

--- a/lib/BoundsUtilities.js
+++ b/lib/BoundsUtilities.js
@@ -1,0 +1,46 @@
+// Returns a Float32Array representing the bounds data for the sphere
+// and box. Assumes that both bounds are centered about the same spot
+// and that the box min and max are equal distance in every dimension
+function boundsToArray( bx, sp ) {
+
+	const arr = new Float64Array( 4 );
+	arr[ 0 ] = sp.radius;
+
+	arr[ 1 ] = sp.center.x;
+	arr[ 2 ] = sp.center.y;
+	arr[ 3 ] = sp.center.z;
+
+	arr[ 4 ] = bx.max.x - sp.center.x;
+	arr[ 5 ] = bx.max.y - sp.center.y;
+	arr[ 6 ] = bx.max.z - sp.center.z;
+
+	return arr;
+
+}
+
+function arrayToSphere( arr, target ) {
+
+	target.radius = arr[ 0 ];
+	target.center.x = arr[ 1 ];
+	target.center.y = arr[ 2 ];
+	target.center.z = arr[ 3 ];
+
+	return target;
+
+}
+
+function arrayToBox( arr, target ) {
+
+	target.min.x = arr[ 1 ] - arr[ 4 ];
+	target.min.y = arr[ 2 ] - arr[ 5 ];
+	target.min.z = arr[ 3 ] - arr[ 6 ];
+
+	target.max.x = arr[ 1 ] + arr[ 4 ];
+	target.max.y = arr[ 2 ] + arr[ 5 ];
+	target.max.z = arr[ 3 ] + arr[ 6 ];
+
+	return target;
+
+}
+
+export { boundsToArray, arrayToBox, arrayToSphere };

--- a/lib/MeshBVH.js
+++ b/lib/MeshBVH.js
@@ -1,5 +1,6 @@
 import * as THREE from '../node_modules/three/build/three.module.js';
 import MeshBVHNode from './MeshBVHNode.js';
+import { boundsToArray } from './BoundsUtilities.js';
 
 import {
 	getBufferGeometryVertexElem, getGeometryVertexElem, getLongestEdgeIndex, getAverage,
@@ -266,6 +267,8 @@ class MeshBVH extends MeshBVHNode {
 		// faster than recursing
 		const avgtemp = new THREE.Vector3();
 		const vectemp = new THREE.Vector3();
+		const bbtemp = new THREE.Box3();
+		const sptemp = new THREE.Sphere();
 		const queue = [];
 		const createNode = ( tris, bb, newNode ) => {
 
@@ -273,16 +276,15 @@ class MeshBVH extends MeshBVHNode {
 			node.geometry = geo;
 
 			// get the bounds of the triangles
-			node.boundingBox = bb;
 
 			// Create the bounding sphere with the minium radius
 			// It's possible that the bounds sphere will have a smaller
 			// radius because the bounds do not encapsulate full triangles
 			// on an edge
-			node.boundingSphere = new THREE.Sphere();
-			bb.getCenter( node.boundingSphere.center );
-			node.boundingSphere.radius = vectemp.subVectors( bb.max, node.boundingSphere.center ).length();
-			shrinkSphereTo( tris, node.boundingSphere, geo, vertexElem );
+			bb.getCenter( sptemp.center );
+			sptemp.radius = vectemp.subVectors( bb.max, sptemp.center ).length();
+			shrinkSphereTo( tris, sptemp, geo, vertexElem );
+			node.boundingData = boundsToArray( bb, sptemp );
 
 			// early out wif we've met our capacity
 			if ( tris.length <= maxLeafNodes ) {
@@ -294,7 +296,7 @@ class MeshBVH extends MeshBVHNode {
 
 			// Find where to split the volume
 			getAverage( tris, avgtemp, geo, vertexElem );
-			const split = splitStrategy( node.boundingBox, node.boundingSphere, avgtemp, tris, geo );
+			const split = splitStrategy( bb, sptemp, avgtemp, tris, geo );
 			if ( split.axis === - 1 ) {
 
 				node.tris = tris;
@@ -334,6 +336,8 @@ class MeshBVH extends MeshBVHNode {
 				node.tris = tris;
 
 			} else {
+
+				node.children = [];
 
 				// create the bounds for the left child, keeping it within
 				// the bounds of the parent and split plane

--- a/lib/MeshBVH.js
+++ b/lib/MeshBVH.js
@@ -267,7 +267,6 @@ class MeshBVH extends MeshBVHNode {
 		// faster than recursing
 		const avgtemp = new THREE.Vector3();
 		const vectemp = new THREE.Vector3();
-		const bbtemp = new THREE.Box3();
 		const sptemp = new THREE.Sphere();
 		const queue = [];
 		const createNode = ( tris, bb, newNode ) => {

--- a/lib/MeshBVHNode.js
+++ b/lib/MeshBVHNode.js
@@ -1,23 +1,33 @@
 
 import * as THREE from '../node_modules/three/build/three.module.js';
 import { intersectTris, intersectClosestTri } from './GeometryUtilities.js';
+import { arrayToSphere, arrayToBox } from './BoundsUtilities.js';
 
 const intersectvec = new THREE.Vector3();
+const boundingBox = new THREE.Box3();
+const boundingSphere = new THREE.Sphere();
 
 export default
 class MeshBVHNode {
 
 	constructor() {
 
-		this.boundingBox = null;
-		this.boundingSphere = null;
+		this.boundingData = null;
 		this.geometry = null;
 		this.tris = null;
-		this.children = [];
+		this.children = null;
 
 	}
 
 	intersectsRay( ray ) {
+
+		arrayToSphere( this.boundingData, boundingSphere );
+
+		if ( ! ray.intersectsSphere( boundingSphere ) ) return false;
+
+		arrayToBox( this.boundingData, boundingBox );
+
+		return ray.intersectsBox( boundingBox );
 
 		return ray.intersectsSphere( this.boundingSphere ) && ray.intersectsBox( this.boundingBox );
 
@@ -43,11 +53,13 @@ class MeshBVHNode {
 		} else {
 
 			const c1 = this.children[ 0 ];
-			intersectvec.subVectors( c1.boundingSphere.center, ray.origin );
+			arrayToSphere( c1.boundingData, boundingSphere );
+			intersectvec.subVectors( boundingSphere.center, ray.origin );
 			const c1dist = intersectvec.length() * intersectvec.dot( ray.direction );
 
 			const c2 = this.children[ 1 ];
-			intersectvec.subVectors( c2.boundingSphere.center, ray.origin );
+			arrayToSphere( c2.boundingData, boundingSphere );
+			intersectvec.subVectors( boundingSphere.center, ray.origin );
 			const c2dist = intersectvec.length() * intersectvec.dot( ray.direction );
 
 			return c1dist < c2dist

--- a/lib/MeshBVHNode.js
+++ b/lib/MeshBVHNode.js
@@ -29,8 +29,6 @@ class MeshBVHNode {
 
 		return ray.intersectsBox( boundingBox );
 
-		return ray.intersectsSphere( this.boundingSphere ) && ray.intersectsBox( this.boundingBox );
-
 	}
 
 	raycast( mesh, raycaster, ray, intersects, seenFaces ) {


### PR DESCRIPTION
Save memory by storing the box and sphere bounds data in a Float32Array of 7 values:

```
0: sphere radius
1, 2, 3: bounds center
4, 5, 6: half box extents
```

The change also sets `children` to null by default.

Here's the benchmark data. The torus knot was generated with the following parameters:
`const geometry = new THREE.TorusBufferGeometry( 5, 5, 400, 100 );`

Benchmarks on master:
```
Compute Bounds Tree      : 395.25 ms
Default Raycast          : 5.065767 ms
BVH Raycast              : 1.157732 ms
First Hit Raycast        : 0.147442 ms

Memory Usage             : 22870.854 kb
```
Benchmarks on this branch:
```
Compute Bounds Tree      : 381.375 ms
Default Raycast          : 4.957096 ms
BVH Raycast              : 1.136364 ms
First Hit Raycast        : 0.143314 ms

Memory Usage             : 12109.59 kb
```
So the memory is (nearly) halved in this case.

