### PR TITLE
Remove geometry instance from BVH nodes

### DIFF
--- a/lib/MeshBVH.js
+++ b/lib/MeshBVH.js
@@ -45,12 +45,26 @@ class MeshBVH extends MeshBVHNode {
 		if ( geo.isBufferGeometry || geo.isGeometry ) {
 
 			this._root = this._buildTree( geo, strategy );
+			this._geometry = geo;
 
 		} else {
 
 			throw new Error( 'Object is not Geometry or BufferGeometry' );
 
 		}
+
+	}
+
+
+	raycastFirst( mesh, raycaster, ray ) {
+
+		return MeshBVH.raycastFirst( this, mesh, this._geometry, raycaster, ray );
+
+	}
+
+	raycast( mesh, raycaster, ray, intersects, seenFaces ) {
+
+		return MeshBVH.raycast( this, mesh, this._geometry, raycaster, ray, intersects, seenFaces );
 
 	}
 
@@ -270,7 +284,6 @@ class MeshBVH extends MeshBVHNode {
 		const createNode = ( tris, bb, newNode ) => {
 
 			const node = newNode || new MeshBVHNode();
-			node.geometry = geo;
 
 			// get the bounds of the triangles
 			node.boundingBox = bb;

--- a/lib/MeshBVHNode.js
+++ b/lib/MeshBVHNode.js
@@ -11,48 +11,47 @@ class MeshBVHNode {
 
 		this.boundingBox = null;
 		this.boundingSphere = null;
-		this.geometry = null;
 		this.tris = null;
 		this.children = [];
 
 	}
 
-	intersectsRay( ray ) {
+	static intersectsRay( node, ray ) {
 
-		return ray.intersectsSphere( this.boundingSphere ) && ray.intersectsBox( this.boundingBox );
-
-	}
-
-	raycast( mesh, raycaster, ray, intersects, seenFaces ) {
-
-		if ( ! this.intersectsRay( ray ) ) return;
-
-		if ( this.tris ) intersectTris( mesh, this.geometry, raycaster, ray, this.tris, intersects, seenFaces );
-		else this.children.forEach( c => c.raycast( mesh, raycaster, ray, intersects, seenFaces ) );
+		return ray.intersectsSphere( node.boundingSphere ) && ray.intersectsBox( node.boundingBox );
 
 	}
 
-	raycastFirst( mesh, raycaster, ray ) {
+	static raycast( node, mesh, geometry, raycaster, ray, intersects, seenFaces ) {
 
-		if ( ! this.intersectsRay( ray ) ) return null;
+		if ( ! this.intersectsRay( node, ray ) ) return;
 
-		if ( this.tris ) {
+		if ( node.tris ) intersectTris( mesh, geometry, raycaster, ray, node.tris, intersects, seenFaces );
+		else node.children.forEach( c => this.raycast( c, mesh, geometry, raycaster, ray, intersects, seenFaces ) );
 
-			return intersectClosestTri( mesh, this.geometry, raycaster, ray, this.tris );
+	}
+
+	static raycastFirst( node, mesh, geometry, raycaster, ray ) {
+
+		if ( ! this.intersectsRay( node, ray ) ) return null;
+
+		if ( node.tris ) {
+
+			return intersectClosestTri( mesh, geometry, raycaster, ray, node.tris );
 
 		} else {
 
-			const c1 = this.children[ 0 ];
+			const c1 = node.children[ 0 ];
 			intersectvec.subVectors( c1.boundingSphere.center, ray.origin );
 			const c1dist = intersectvec.length() * intersectvec.dot( ray.direction );
 
-			const c2 = this.children[ 1 ];
+			const c2 = node.children[ 1 ];
 			intersectvec.subVectors( c2.boundingSphere.center, ray.origin );
 			const c2dist = intersectvec.length() * intersectvec.dot( ray.direction );
 
 			return c1dist < c2dist
-				? c1.raycastFirst( mesh, raycaster, ray ) || c2.raycastFirst( mesh, raycaster, ray )
-				: c2.raycastFirst( mesh, raycaster, ray ) || c1.raycastFirst( mesh, raycaster, ray );
+				? this.raycastFirst( c1, mesh, geometry, raycaster, ray ) || this.raycastFirst( c2, mesh, geometry, raycaster, ray )
+				: this.raycastFirst( c2, mesh, geometry, raycaster, ray ) || this.raycastFirst( c1, mesh, geometry, raycaster, ray );
 
 		}
 


### PR DESCRIPTION
Removes the geometry instance reference from the BVH node itself to try to save a bit of memory.

Benchmarks on master:
```
Compute Bounds Tree      : 395.25 ms
Default Raycast          : 5.065767 ms
BVH Raycast              : 1.157732 ms
First Hit Raycast        : 0.147442 ms

Memory Usage             : 22870.854 kb
```
Benchmarks on this branch:
```
Compute Bounds Tree      : 399.125 ms
Default Raycast          : 5.096774 ms
BVH Raycast              : 1.187648 ms
First Hit Raycast        : 0.147944 ms

Memory Usage             : 21675.176 kb
```

Memory savings are minimal but probably still worth it. A cleaner solution may be to just use the `geometry` reference on the passed `mesh` object instead of storing it separately.