### PR TITLE
Use an optimal triangle array to store the triangle indices

### DIFF
--- a/lib/MeshBVH.js
+++ b/lib/MeshBVH.js
@@ -5,6 +5,30 @@ import {
 	getBufferGeometryVertexElem, getGeometryVertexElem, getLongestEdgeIndex, getAverage,
 	shrinkBoundsTo, shrinkSphereTo } from './GeometryUtilities.js';
 
+function toOptimalArray( arr ) {
+
+	let sz = 8;
+
+	for ( let i = 0; i < arr.length; i ++ ) {
+
+		const v = arr[ i ];
+
+		while ( Math.pow( 2, sz ) <= v ) {
+
+			sz *= 2;
+
+		}
+
+	}
+
+	const type = `Uint${ sz }Array`;
+	const typedArr = global[ type ].from( arr, v => ~ ~ v );
+
+	return typedArr;
+
+}
+
+
 // Settings
 const maxLeafNodes = 10;
 const Strategies = {
@@ -287,7 +311,7 @@ class MeshBVH extends MeshBVHNode {
 			// early out wif we've met our capacity
 			if ( tris.length <= maxLeafNodes ) {
 
-				node.tris = tris;
+				node.tris = toOptimalArray( tris );
 				return node;
 
 			}
@@ -297,7 +321,7 @@ class MeshBVH extends MeshBVHNode {
 			const split = splitStrategy( node.boundingBox, node.boundingSphere, avgtemp, tris, geo );
 			if ( split.axis === - 1 ) {
 
-				node.tris = tris;
+				node.tris = toOptimalArray( tris );
 				return node;
 
 			}


### PR DESCRIPTION
Uses a typed array of optimal size to store triangle indices rather than the default 64 bit numbers. So if the indices stored in the array will fit in 8 bits then a `Uint8Array` will be used.

Benchmarks on master:
```
Compute Bounds Tree      : 395.25 ms
Default Raycast          : 5.065767 ms
BVH Raycast              : 1.157732 ms
First Hit Raycast        : 0.147442 ms

Memory Usage             : 22870.854 kb
```
Benchmarks on this branch:
```
Compute Bounds Tree      : 419.5 ms
Default Raycast          : 4.849758 ms
BVH Raycast              : 1.156961 ms
First Hit Raycast        : 0.138902 ms

Memory Usage             : 20958.404 kb
```