### PR TITLE
Bring visualizer up to date with mesh node structure

### DIFF
--- a/lib/MeshBVHVisualizer.js
+++ b/lib/MeshBVHVisualizer.js
@@ -1,7 +1,9 @@
 import * as THREE from '../node_modules/three/build/three.module.js';
+import { arrayToBox } from './BoundsUtilities.js';
 
 const wiremat = new THREE.LineBasicMaterial( { color: 0x00FF88, transparent: true, opacity: 0.3 } );
 const boxGeom = new THREE.Box3Helper().geometry;
+let boundingBox = new THREE.Box3();
 
 class MeshBVHVisualizer extends THREE.Object3D {
 
@@ -32,7 +34,7 @@ class MeshBVHVisualizer extends THREE.Object3D {
 
 					if ( d === this.depth ) return;
 
-					if ( d === this.depth - 1 || n.children.length === 0 ) {
+					if ( d === this.depth - 1 || n.children == null || n.children.length === 0 ) {
 
 						let m = requiredChildren < this.children.length ? this.children[ requiredChildren ] : null;
 						if ( ! m ) {
@@ -43,12 +45,17 @@ class MeshBVHVisualizer extends THREE.Object3D {
 
 						}
 						requiredChildren ++;
-						n.boundingBox.getCenter( m.position );
-						m.scale.subVectors( n.boundingBox.max, n.boundingBox.min ).multiplyScalar( 0.5 );
+						arrayToBox( n.boundingData, boundingBox );
+						boundingBox.getCenter( m.position );
+						m.scale.subVectors( boundingBox.max, boundingBox.min ).multiplyScalar( 0.5 );
 
 					}
-					n.children.forEach( n => recurse( n, d + 1 ) );
 
+					if ( n.children != null ) {
+
+						n.children.forEach( n => recurse( n, d + 1 ) );
+
+					}
 				};
 
 				recurse( this._boundsTree._root, 0 );


### PR DESCRIPTION
Self-explanatory, this broke with the recent changes to `MeshBVHNode`.