### PR TITLE
Don't do work for split strategies we aren't using

### DIFF
--- a/lib/MeshBVH.js
+++ b/lib/MeshBVH.js
@@ -97,7 +97,10 @@ class MeshBVH extends MeshBVHNode {
 
 		}
 
-		const splitStrategy = ( bounds, center, avg, tris ) => {
+		const avgtemp = new THREE.Vector3();
+		const centertemp = new THREE.Vector3();
+
+		const splitStrategy = ( bounds, tris, centroids ) => {
 
 			let axis = - 1;
 			let pos = 0;
@@ -106,13 +109,14 @@ class MeshBVH extends MeshBVHNode {
 			if ( strategy === SplitStrategy.CENTER ) {
 
 				axis = getLongestEdgeIndex( bounds );
-				const field = xyzFields[ axis ];
-				pos = center[ field ];
+				bounds.getCenter( centertemp );
+				pos = centertemp[ xyzFields[ axis ] ];
 
 			} else if ( strategy === SplitStrategy.AVERAGE ) {
 
 				axis = getLongestEdgeIndex( bounds );
-				pos = avg[ xyzFields[ axis ] ];
+				getAverage( tris, centroids, avgtemp );
+				pos = avgtemp[ xyzFields[ axis ] ];
 
 			} else if ( strategy === SplitStrategy.SAH ) {
 
@@ -260,8 +264,6 @@ class MeshBVH extends MeshBVHNode {
 		// because otherwise we run the risk of a stackoverflow
 		// In the case of buffer geometry it also seems to be
 		// faster than recursing
-		const avgtemp = new THREE.Vector3();
-		const centertemp = new THREE.Vector3();
 		const queue = [];
 		const createNode = ( tris, bb, newNode, depth = 0 ) => {
 
@@ -280,9 +282,7 @@ class MeshBVH extends MeshBVHNode {
 			}
 
 			// Find where to split the volume
-			bb.getCenter( centertemp );
-			getAverage( tris, centroids, avgtemp );
-			const split = splitStrategy( bb, centertemp, avgtemp, tris );
+			const split = splitStrategy( bb, tris, centroids );
 			if ( split.axis === - 1 ) {
 
 				node.tris = tris;


### PR DESCRIPTION
Self-explanatory. The averaging was the substantial part which is nice to avoid if we don't need to do it. No big deal, though -- it shaves off maybe just a few percent on the benchmark in tree construction for the CENTER strategy:

```
Compute Bounds Tree      : 36.22 ms
Default Raycast          : 1.753361 ms
BVH Raycast              : 0.183453 ms
First Hit Raycast        : 0.099249 ms

Total Memory Usage       : 2633.052 kb
Geometry Memory Usage    : 1134.216 kb
Bounds Tree Memory Usage : 1498.836 kb
```