### PR TITLE
Don't do extra work when splitting

### DIFF
--- a/src/BVHConstructionContext.js
+++ b/src/BVHConstructionContext.js
@@ -230,15 +230,19 @@ export default class BVHConstructionContext {
 		if ( strategy === SplitStrategy.CENTER ) {
 
 			axis = getLongestEdgeIndex( bounds );
-			if (axis !== -1) {
-				pos = (bounds[ axis + 3 ] + bounds[ axis ]) / 2;
+			if ( axis !== - 1 ) {
+
+				pos = ( bounds[ axis + 3 ] + bounds[ axis ] ) / 2;
+
 			}
 
 		} else if ( strategy === SplitStrategy.AVERAGE ) {
 
 			axis = getLongestEdgeIndex( bounds );
-			if (axis !== -1) {
+			if ( axis !== - 1 ) {
+
 				pos = this.getAverage( offset, count, axis );
+
 			}
 
 		} else if ( strategy === SplitStrategy.SAH ) {

--- a/src/BoundsUtilities.js
+++ b/src/BoundsUtilities.js
@@ -48,6 +48,6 @@ function getLongestEdgeIndex( bounds ) {
 
 	return splitDimIdx;
 
-};
+}
 
 export { boundsToArray, arrayToBox, getLongestEdgeIndex };

--- a/src/BoundsUtilities.js
+++ b/src/BoundsUtilities.js
@@ -29,4 +29,25 @@ function arrayToBox( arr, target ) {
 
 }
 
-export { boundsToArray, arrayToBox };
+function getLongestEdgeIndex( bounds ) {
+
+	let splitDimIdx = - 1;
+	let splitDist = - Infinity;
+
+	for ( let i = 0; i < 3; i ++ ) {
+
+		const dist = bounds[ i + 3 ] - bounds[ i ];
+		if ( dist > splitDist ) {
+
+			splitDist = dist;
+			splitDimIdx = i;
+
+		}
+
+	}
+
+	return splitDimIdx;
+
+};
+
+export { boundsToArray, arrayToBox, getLongestEdgeIndex };

--- a/src/GeometryUtilities.js
+++ b/src/GeometryUtilities.js
@@ -1,28 +1,5 @@
 import { checkBufferGeometryIntersection } from './IntersectionUtilities.js';
 
-const xyzFields = [ 'x', 'y', 'z' ];
-
-const getLongestEdgeIndex = ( bb ) => {
-
-	let splitDimIdx = - 1;
-	let splitDist = - Infinity;
-	for ( let i = 0; i < xyzFields.length; i ++ ) {
-
-		const d = xyzFields[ i ];
-		const dist = bb.max[ d ] - bb.min[ d ];
-		if ( dist > splitDist ) {
-
-			splitDist = dist;
-			splitDimIdx = i;
-
-		}
-
-	}
-
-	return splitDimIdx;
-
-};
-
 // For BVH code specifically. Does not check morph targets
 // Copied from mesh raycasting
 // Ripped an modified from the THREE.js source in Mesh.CS
@@ -78,5 +55,5 @@ const intersectClosestTri = ( mesh, geo, raycaster, ray, offset, count ) => {
 };
 
 export {
-	getLongestEdgeIndex, intersectTri, intersectTris, intersectClosestTri
+	intersectTri, intersectTris, intersectClosestTri
 };

--- a/src/MeshBVH.js
+++ b/src/MeshBVH.js
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 import MeshBVHNode from './MeshBVHNode.js';
 import BVHConstructionContext from './BVHConstructionContext.js';
-import { arrayToBox, boundsToArray } from './BoundsUtilities.js';
+import { boundsToArray } from './BoundsUtilities.js';
 
 export default class MeshBVH extends MeshBVHNode {
 
@@ -38,7 +38,6 @@ export default class MeshBVH extends MeshBVHNode {
 		const verticesLength = geo.attributes.position.count;
 		const indicesLength = ctx.tris.length * 3;
 		const indices = new ( verticesLength < 65536 ? Uint16Array : Uint32Array )( indicesLength );
-		const boxtemp = new THREE.Box3();
 
 		// either recursively splits the given node, creating left and right subtrees for it, or makes it a leaf node,
 		// recording the offset and count of its triangles and writing them into the reordered geometry index.
@@ -55,8 +54,7 @@ export default class MeshBVH extends MeshBVHNode {
 			}
 
 			// Find where to split the volume
-			arrayToBox( node.boundingData, boxtemp );
-			const split = ctx.getOptimalSplit( boxtemp, offset, count, options.strategy );
+			const split = ctx.getOptimalSplit( node.boundingData, offset, count, options.strategy );
 			if ( split.axis === - 1 ) {
 
 				ctx.writeReorderedIndices( offset, count, indices );


### PR DESCRIPTION
Pretty self-explanatory. This really moves the needle on the AVERAGE strategy, but even for CENTER it shaves off a percentage point or two on tree construction time (much easier to see with the new larger benchmark.)
