### PR TITLE
Raycast first optimization

### DIFF
--- a/src/MeshBVHNode.js
+++ b/src/MeshBVHNode.js
@@ -53,7 +53,6 @@ class MeshBVHNode {
 			const xyzAxis = xyzFields[ splitAxis ];
 			const rayDir = ray.direction[ xyzAxis ];
 			const leftToRight = rayDir >= 0;
-			const l2rFactor = leftToRight ? - 1 : 1;
 
 			let c1, c2;
 			if ( leftToRight ) {
@@ -70,18 +69,19 @@ class MeshBVHNode {
 
 			const c1Intersection = c1.intersectRay( ray, boxIntersection );
 			const c1Result = c1Intersection ? c1.raycastFirst( mesh, raycaster, ray ) : null;
-			const c2Intersection = c2.intersectRay( ray, boxIntersection );
 
 			// if we got an intersection in the first node and it's closer than the second node's bounding
 			// box, we don't need to consider the second node because it couldn't possibly be a better result
 
-			if ( c1Result && c2Intersection ) {
+			if ( c1Result ) {
 
 				const rayOrig = ray.origin[ xyzAxis ];
 				const toPoint = rayOrig - c1Result.point[ xyzAxis ];
-				const toChild = rayOrig - c2Intersection[ xyzAxis ];
+				const toChild1 = rayOrig - c2.boundingData[ splitAxis ];
+				const toChild2 = rayOrig - c2.boundingData[ splitAxis + 3 ];
 
-				if ( toPoint * toPoint <= toChild * toChild ) {
+				const toPoint2 = toPoint * toPoint;
+				if ( toPoint2 <= toChild1 * toChild1 && toPoint2 <= toChild2 * toChild2 ) {
 
 					return c1Result;
 
@@ -91,7 +91,7 @@ class MeshBVHNode {
 
 			// either there was no intersection in the first node, or there could still be a closer
 			// intersection in the second, so check the second node and then take the better of the two
-
+			const c2Intersection = c2.intersectRay( ray, boxIntersection );
 			const c2Result = c2Intersection ? c2.raycastFirst( mesh, raycaster, ray ) : null;
 
 			if ( c1Result && c2Result ) {

--- a/src/MeshBVHNode.js
+++ b/src/MeshBVHNode.js
@@ -45,12 +45,28 @@ class MeshBVHNode {
 
 		} else {
 
+
 			// consider the position of the split plane with respect to the oncoming ray; whichever direction
 			// the ray is coming from, look for an intersection among that side of the tree first
+			const children = this.children;
+			const splitAxis = this.splitAxis;
+			const xyzAxis = xyzFields[ splitAxis ];
+			const rayDir = ray.direction[ xyzAxis ];
+			const leftToRight = rayDir >= 0;
+			const l2rFactor = leftToRight ? - 1 : 1;
 
-			const leftToRight = ray.direction[ xyzFields[ this.splitAxis ] ] >= 0;
-			const c1 = leftToRight ? this.children[ 0 ] : this.children[ 1 ];
-			const c2 = leftToRight ? this.children[ 1 ] : this.children[ 0 ];
+			let c1, c2;
+			if ( leftToRight ) {
+
+				c1 = children[ 0 ];
+				c2 = children[ 1 ];
+
+			} else {
+
+				c1 = children[ 1 ];
+				c2 = children[ 0 ];
+
+			}
 
 			const c1Intersection = c1.intersectRay( ray, boxIntersection );
 			const c1Result = c1Intersection ? c1.raycastFirst( mesh, raycaster, ray ) : null;
@@ -61,7 +77,11 @@ class MeshBVHNode {
 
 			if ( c1Result && c2Intersection ) {
 
-				if ( c1Result.distance * c1Result.distance <= ray.origin.distanceToSquared( c2Intersection ) ) {
+				const rayOrig = ray.origin[ xyzAxis ];
+				const toPoint = rayOrig - c1Result.point[ xyzAxis ];
+				const toChild = rayOrig - c2Intersection[ xyzAxis ];
+
+				if ( toPoint * toPoint <= toChild * toChild ) {
 
 					return c1Result;
 

--- a/src/MeshBVHNode.js
+++ b/src/MeshBVHNode.js
@@ -54,6 +54,7 @@ class MeshBVHNode {
 			const rayDir = ray.direction[ xyzAxis ];
 			const leftToRight = rayDir >= 0;
 
+			// c1 is the child to check first
 			let c1, c2;
 			if ( leftToRight ) {
 
@@ -72,16 +73,16 @@ class MeshBVHNode {
 
 			// if we got an intersection in the first node and it's closer than the second node's bounding
 			// box, we don't need to consider the second node because it couldn't possibly be a better result
-
 			if ( c1Result ) {
 
+				// check only along the split axis
 				const rayOrig = ray.origin[ xyzAxis ];
 				const toPoint = rayOrig - c1Result.point[ xyzAxis ];
 				const toChild1 = rayOrig - c2.boundingData[ splitAxis ];
 				const toChild2 = rayOrig - c2.boundingData[ splitAxis + 3 ];
 
-				const toPoint2 = toPoint * toPoint;
-				if ( toPoint2 <= toChild1 * toChild1 && toPoint2 <= toChild2 * toChild2 ) {
+				const toPointSq = toPoint * toPoint;
+				if ( toPointSq <= toChild1 * toChild1 && toPointSq <= toChild2 * toChild2 ) {
 
 					return c1Result;
 


### PR DESCRIPTION
@mquander 

This optimizes the `raycastFirst` path to speed things up a bit. The big change is only checking the ray along the split axis to decide if we should return the c1 intersection result. This means we don't always do a full c2 bounds check when the correct result is in the first child. With this change I'm back up to the as-advertised 500 intersections at 60fps in the readme (on my machine, at least...)

Here are the benchmarks:

*Before*
```
First Hit Raycast        : 0.10469 ms
```

*After*
```
First Hit Raycast        : 0.02901 ms
```

Fix #38 